### PR TITLE
Fix CSV export corruption, locale-dependent formatting, and error isolation

### DIFF
--- a/ActivityLogger.cs
+++ b/ActivityLogger.cs
@@ -1,0 +1,28 @@
+using System;
+using System.IO;
+
+namespace VMS.TPS
+{
+    // Registro mínimo de auditoría (qué análisis se ejecutaron y qué se exportó) para
+    // trazabilidad institucional. Debe ser "best effort": un fallo al escribir el log
+    // nunca debe interrumpir el flujo de análisis/exportación clínico.
+    public static class ActivityLogger
+    {
+        private static readonly string LogDir = @"C:\Temp\PortalDosimetryReports\Logs";
+
+        public static void Log(string message)
+        {
+            try
+            {
+                if (!Directory.Exists(LogDir)) Directory.CreateDirectory(LogDir);
+                string file = Path.Combine(LogDir, $"HalcyonQA_Activity_{DateTime.Now:yyyyMM}.log");
+                string line = $"{DateTime.Now:yyyy-MM-dd HH:mm:ss}\t{Environment.UserName}\t{message}";
+                File.AppendAllText(file, line + Environment.NewLine);
+            }
+            catch
+            {
+                // Intencional: el registro de auditoría no debe bloquear el análisis clínico.
+            }
+        }
+    }
+}

--- a/AnalysisResult.cs
+++ b/AnalysisResult.cs
@@ -1,0 +1,12 @@
+namespace VMS.TPS
+{
+    public class AnalysisResult
+    {
+        public string FieldId { get; set; }
+        public string Date { get; set; }
+        public int SessionNumber { get; set; }
+        public double GammaPassRate { get; set; }
+        public string Status { get; set; }
+        public string Details { get; set; }
+    }
+}

--- a/AssemblyInfo.cs
+++ b/AssemblyInfo.cs
@@ -1,0 +1,10 @@
+using System.Reflection;
+using VMS.TPS.Common.Model.API;
+
+[assembly: AssemblyVersion("1.0.0.1")]
+[assembly: AssemblyFileVersion("1.0.0.1")]
+[assembly: AssemblyInformationalVersion("1.0")]
+
+// Este script solo lee imágenes de dosimetría portal y exporta un CSV a disco local;
+// no modifica ni guarda ningún dato del plan/paciente en Eclipse.
+[assembly: ESAPIScript(IsWriteable = false)]

--- a/GammaCalculator.cs
+++ b/GammaCalculator.cs
@@ -1,0 +1,185 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using System.Windows;
+
+namespace VMS.TPS
+{
+    public class GammaCalculator
+    {
+        private const double DTA_CRITERIA = 3.0; // mm
+        private const double DOSE_CRITERIA_PERCENT = 0.03; // 3%
+        private const double THRESHOLD_PERCENT = 0.10; // 10%
+        private const double PASS_LIMIT = 95.0; // %
+
+        // Cálculo puro sobre arrays ya extraídos (sin dependencias de ESAPI): seguro de llamar
+        // desde un hilo de fondo y de paralelizar.
+        public static AnalysisResult Evaluate(PortalDoseSnapshot imgRef, PortalDoseSnapshot imgEval, int sessionIdx)
+        {
+            string fieldId = imgRef.FieldId ?? imgEval.FieldId ?? "N/A";
+            string dateStr = imgEval.Date;
+
+            int sizeX = imgRef.XSize;
+            int sizeY = imgRef.YSize;
+            double resX = imgRef.XRes;
+
+            if (imgEval.XSize != sizeX || imgEval.YSize != sizeY)
+            {
+                return new AnalysisResult
+                {
+                    FieldId = fieldId,
+                    Date = dateStr,
+                    SessionNumber = sessionIdx,
+                    GammaPassRate = 0,
+                    Status = "ERROR",
+                    Details = $"Tamaño de imagen distinto (Ref: {sizeX}x{sizeY}, Eval: {imgEval.XSize}x{imgEval.YSize})"
+                };
+            }
+
+            if (Math.Abs(imgEval.XRes - resX) > 1e-6 || Math.Abs(imgEval.YRes - imgRef.YRes) > 1e-6)
+            {
+                return new AnalysisResult
+                {
+                    FieldId = fieldId,
+                    Date = dateStr,
+                    SessionNumber = sessionIdx,
+                    GammaPassRate = 0,
+                    Status = "ERROR",
+                    Details = $"Resolución distinta (Ref: {resX:F3}mm, Eval: {imgEval.XRes:F3}mm)"
+                };
+            }
+
+            int[,] buffRef = imgRef.Voxels;
+            int[,] buffEval = imgEval.Voxels;
+
+            int maxDoseRef = 0;
+            int maxDoseEval = 0;
+            for (int x = 0; x < sizeX; x++)
+            {
+                for (int y = 0; y < sizeY; y++)
+                {
+                    if (buffRef[x, y] > maxDoseRef) maxDoseRef = buffRef[x, y];
+                    if (buffEval[x, y] > maxDoseEval) maxDoseEval = buffEval[x, y];
+                }
+            }
+
+            if (maxDoseRef <= 0) return new AnalysisResult { FieldId = fieldId, Date = dateStr, SessionNumber = sessionIdx, Status = "ERROR", Details = "Ref Vacía" };
+
+            // Auto-Alineación (Using each image's own max dose for thresholding)
+            Point comRef = GetCenterOfMass(buffRef, sizeX, sizeY, maxDoseRef * 0.2);
+            Point comEval = GetCenterOfMass(buffEval, sizeX, sizeY, maxDoseEval * 0.2);
+
+            int shiftX = (int)Math.Round(comRef.X - comEval.X);
+            int shiftY = (int)Math.Round(comRef.Y - comEval.Y);
+
+            // Gamma
+            double doseTol = maxDoseRef * DOSE_CRITERIA_PERCENT;
+            double distTolSq = DTA_CRITERIA * DTA_CRITERIA;
+            double thresholdVal = maxDoseRef * THRESHOLD_PERCENT;
+            int searchRadiusX = (int)Math.Ceiling(DTA_CRITERIA / resX) + 1;
+
+            // El patrón de desplazamientos (dx, dy) a explorar es el mismo para todos los puntos
+            // de la imagen (depende solo del radio y la resolución), así que se calcula una única
+            // vez, ordenado por distancia ascendente, para poder cortar la búsqueda en cuanto un
+            // punto cumple el criterio de gamma en vez de recorrer siempre toda la ventana.
+            var searchOffsets = BuildSearchOffsets(searchRadiusX, resX, distTolSq);
+
+            int pointsEvaluated = 0;
+            int pointsPassed = 0;
+            object sumLock = new object();
+
+            // Cada fila (x) es independiente: se reparte entre hilos y se combinan los totales al final.
+            Parallel.For(0, sizeX,
+                () => (evaluated: 0, passed: 0),
+                (x, loopState, local) =>
+                {
+                    int localEvaluated = local.evaluated;
+                    int localPassed = local.passed;
+
+                    for (int y = 0; y < sizeY; y++)
+                    {
+                        double dRef = buffRef[x, y];
+                        if (dRef < thresholdVal) continue;
+
+                        localEvaluated++;
+                        int xEvalBase = x - shiftX;
+                        int yEvalBase = y - shiftY;
+
+                        if (IsInside(xEvalBase, yEvalBase, sizeX, sizeY) &&
+                            Math.Abs(dRef - buffEval[xEvalBase, yEvalBase]) <= doseTol)
+                        {
+                            localPassed++;
+                            continue;
+                        }
+
+                        bool passed = false;
+                        foreach (var off in searchOffsets)
+                        {
+                            int i = xEvalBase + off.dx;
+                            int j = yEvalBase + off.dy;
+                            if (!IsInside(i, j, sizeX, sizeY)) continue;
+
+                            double doseDiff = Math.Abs(dRef - buffEval[i, j]);
+                            double gammaSq = (doseDiff * doseDiff) / (doseTol * doseTol) + off.distSqMm / distTolSq;
+
+                            if (gammaSq <= 1.0) { passed = true; break; }
+                        }
+                        if (passed) localPassed++;
+                    }
+
+                    return (localEvaluated, localPassed);
+                },
+                local =>
+                {
+                    lock (sumLock)
+                    {
+                        pointsEvaluated += local.evaluated;
+                        pointsPassed += local.passed;
+                    }
+                });
+
+            double passRate = (double)pointsPassed / Math.Max(1, pointsEvaluated) * 100.0;
+
+            return new AnalysisResult
+            {
+                FieldId = fieldId,
+                Date = dateStr,
+                SessionNumber = sessionIdx,
+                GammaPassRate = passRate,
+                Status = passRate >= PASS_LIMIT ? "APROBADO" : "FALLO",
+                Details = $"Shift: {shiftX},{shiftY} px. Puntos: {pointsEvaluated}"
+            };
+        }
+
+        private static (int dx, int dy, double distSqMm)[] BuildSearchOffsets(int radius, double res, double distTolSq)
+        {
+            var offsets = new List<(int dx, int dy, double distSqMm)>();
+            for (int dx = -radius; dx <= radius; dx++)
+            {
+                for (int dy = -radius; dy <= radius; dy++)
+                {
+                    double distSqMm = (dx * res * dx * res) + (dy * res * dy * res);
+                    if (distSqMm <= distTolSq) offsets.Add((dx, dy, distSqMm));
+                }
+            }
+            return offsets.OrderBy(o => o.distSqMm).ToArray();
+        }
+
+        private static bool IsInside(int x, int y, int sx, int sy) => x >= 0 && x < sx && y >= 0 && y < sy;
+
+        private static Point GetCenterOfMass(int[,] img, int sx, int sy, double thresh)
+        {
+            double sumW = 0, sumX = 0, sumY = 0;
+            for (int x = 0; x < sx; x++)
+            {
+                for (int y = 0; y < sy; y++)
+                {
+                    double val = img[x, y];
+                    if (val > thresh) { sumW += val; sumX += x * val; sumY += y * val; }
+                }
+            }
+            return sumW == 0 ? new Point(sx / 2, sy / 2) : new Point(sumX / sumW, sumY / sumW);
+        }
+    }
+}

--- a/HalcyonGammaCheck_v3.cs
+++ b/HalcyonGammaCheck_v3.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.Globalization;
 using System.IO;
 using System.Linq;
 using System.Reflection;
@@ -68,9 +69,38 @@ namespace VMS.TPS
 
         public static AnalysisResult Evaluate(PortalDoseImage imgRef, PortalDoseImage imgEval, int sessionIdx)
         {
+            string fieldId = imgRef.Beam?.Id ?? imgEval.Beam?.Id ?? "N/A";
+            string dateStr = imgEval.CreationDateTime.HasValue ? imgEval.CreationDateTime.Value.ToShortDateString() : "N/A";
+
             int sizeX = imgRef.XSize;
             int sizeY = imgRef.YSize;
             double resX = imgRef.XRes;
+
+            if (imgEval.XSize != sizeX || imgEval.YSize != sizeY)
+            {
+                return new AnalysisResult
+                {
+                    FieldId = fieldId,
+                    Date = dateStr,
+                    SessionNumber = sessionIdx,
+                    GammaPassRate = 0,
+                    Status = "ERROR",
+                    Details = $"Tamaño de imagen distinto (Ref: {sizeX}x{sizeY}, Eval: {imgEval.XSize}x{imgEval.YSize})"
+                };
+            }
+
+            if (Math.Abs(imgEval.XRes - resX) > 1e-6 || Math.Abs(imgEval.YRes - imgRef.YRes) > 1e-6)
+            {
+                return new AnalysisResult
+                {
+                    FieldId = fieldId,
+                    Date = dateStr,
+                    SessionNumber = sessionIdx,
+                    GammaPassRate = 0,
+                    Status = "ERROR",
+                    Details = $"Resolución distinta (Ref: {resX:F3}mm, Eval: {imgEval.XRes:F3}mm)"
+                };
+            }
 
             // ESAPI Best Practice: GetVoxels requires int[,] arrays
             int[,] buffRef = new int[sizeX, sizeY];
@@ -90,7 +120,7 @@ namespace VMS.TPS
                 }
             }
 
-            if (maxDoseRef <= 0) return new AnalysisResult { FieldId = imgRef.Beam.Id, Status = "ERROR", Details = "Ref Vacía" };
+            if (maxDoseRef <= 0) return new AnalysisResult { FieldId = fieldId, Date = dateStr, SessionNumber = sessionIdx, Status = "ERROR", Details = "Ref Vacía" };
 
             // Auto-Alineación (Using each image's own max dose for thresholding)
             Point comRef = GetCenterOfMass(buffRef, sizeX, sizeY, maxDoseRef * 0.2);
@@ -158,8 +188,8 @@ namespace VMS.TPS
 
             return new AnalysisResult
             {
-                FieldId = imgRef.Beam.Id,
-                Date = imgEval.CreationDateTime.HasValue ? imgEval.CreationDateTime.Value.ToShortDateString() : "N/A",
+                FieldId = fieldId,
+                Date = dateStr,
                 SessionNumber = sessionIdx,
                 GammaPassRate = passRate,
                 Status = passRate >= PASS_LIMIT ? "APROBADO" : "FALLO",
@@ -399,7 +429,23 @@ namespace VMS.TPS
                         for (int i = 1; i < fieldImages.Count; i++) // Empezar en 1 (saltar Ref)
                         {
                             var evalImg = fieldImages[i];
-                            results.Add(GammaCalculator.Evaluate(refImg, evalImg, counter++));
+                            int session = counter++;
+                            try
+                            {
+                                results.Add(GammaCalculator.Evaluate(refImg, evalImg, session));
+                            }
+                            catch (Exception exField)
+                            {
+                                results.Add(new AnalysisResult
+                                {
+                                    FieldId = beam.Id,
+                                    Date = evalImg.CreationDateTime.HasValue ? evalImg.CreationDateTime.Value.ToShortDateString() : "N/A",
+                                    SessionNumber = session,
+                                    GammaPassRate = 0,
+                                    Status = "ERROR",
+                                    Details = exField.Message
+                                });
+                            }
                         }
                     }
 
@@ -422,7 +468,24 @@ namespace VMS.TPS
                     for (int i = 0; i < _singleFieldImages.Count; i++)
                     {
                         if (i == refIdx) continue;
-                        results.Add(GammaCalculator.Evaluate(refImg, _singleFieldImages[i], counter++));
+                        var evalImg = _singleFieldImages[i];
+                        int session = counter++;
+                        try
+                        {
+                            results.Add(GammaCalculator.Evaluate(refImg, evalImg, session));
+                        }
+                        catch (Exception exField)
+                        {
+                            results.Add(new AnalysisResult
+                            {
+                                FieldId = _cbFields.SelectedItem?.ToString(),
+                                Date = evalImg.CreationDateTime.HasValue ? evalImg.CreationDateTime.Value.ToShortDateString() : "N/A",
+                                SessionNumber = session,
+                                GammaPassRate = 0,
+                                Status = "ERROR",
+                                Details = exField.Message
+                            });
+                        }
                     }
                 }
 
@@ -462,12 +525,35 @@ namespace VMS.TPS
                     sw.WriteLine("Paciente,Curso,Plan,Campo,Fecha,Sesion,Gamma,Estado,Detalles");
                     foreach (var r in data)
                     {
-                        sw.WriteLine($"{_patient.Id},{_cbCourses.SelectedItem},{safePlanId},{r.FieldId},{r.Date},{r.SessionNumber},{r.GammaPassRate:F2},{r.Status},{r.Details}");
+                        var fields = new[]
+                        {
+                            CsvField(_patient.Id),
+                            CsvField(_cbCourses.SelectedItem?.ToString()),
+                            CsvField(safePlanId),
+                            CsvField(r.FieldId),
+                            CsvField(r.Date),
+                            CsvField(r.SessionNumber.ToString(CultureInfo.InvariantCulture)),
+                            CsvField(r.GammaPassRate.ToString("F2", CultureInfo.InvariantCulture)),
+                            CsvField(r.Status),
+                            CsvField(r.Details)
+                        };
+                        sw.WriteLine(string.Join(",", fields));
                     }
                 }
                 MessageBox.Show($"Exportado a:\n{file}");
             }
             catch (Exception ex) { MessageBox.Show("Error exportando: " + ex.Message); }
+        }
+
+        // Escapa un campo para CSV (RFC 4180): entrecomilla si contiene coma, comilla o salto de línea.
+        private static string CsvField(string value)
+        {
+            string s = value ?? string.Empty;
+            if (s.IndexOfAny(new[] { ',', '"', '\n', '\r' }) >= 0)
+            {
+                s = "\"" + s.Replace("\"", "\"\"") + "\"";
+            }
+            return s;
         }
     }
 }

--- a/HalcyonGammaCheck_v3.cs
+++ b/HalcyonGammaCheck_v3.cs
@@ -6,6 +6,7 @@ using System.Linq;
 using System.Reflection;
 using System.Runtime.CompilerServices;
 using System.Text;
+using System.Threading.Tasks;
 using System.Windows;
 using System.Windows.Controls;
 using System.Windows.Data;
@@ -60,6 +61,39 @@ namespace VMS.TPS
         public string Details { get; set; }
     }
 
+    // Copia inmutable de los datos de una PortalDoseImage necesarios para el cálculo de gamma.
+    // Se construye en el hilo de UI (donde es seguro llamar a ESAPI) para que el cálculo puro
+    // pueda ejecutarse después en un hilo de fondo sin volver a tocar objetos ESAPI.
+    public class PortalDoseSnapshot
+    {
+        public string FieldId { get; set; }
+        public string Date { get; set; }
+        public int[,] Voxels { get; set; }
+        public int XSize { get; set; }
+        public int YSize { get; set; }
+        public double XRes { get; set; }
+        public double YRes { get; set; }
+
+        public static PortalDoseSnapshot From(PortalDoseImage img, string fieldIdOverride = null)
+        {
+            int sx = img.XSize;
+            int sy = img.YSize;
+            var buff = new int[sx, sy];
+            img.GetVoxels(0, buff);
+
+            return new PortalDoseSnapshot
+            {
+                FieldId = fieldIdOverride ?? img.Beam?.Id,
+                Date = img.CreationDateTime.HasValue ? img.CreationDateTime.Value.ToShortDateString() : "N/A",
+                Voxels = buff,
+                XSize = sx,
+                YSize = sy,
+                XRes = img.XRes,
+                YRes = img.YRes
+            };
+        }
+    }
+
     public class GammaCalculator
     {
         private const double DTA_CRITERIA = 3.0; // mm
@@ -67,10 +101,12 @@ namespace VMS.TPS
         private const double THRESHOLD_PERCENT = 0.10; // 10%
         private const double PASS_LIMIT = 95.0; // %
 
-        public static AnalysisResult Evaluate(PortalDoseImage imgRef, PortalDoseImage imgEval, int sessionIdx)
+        // Cálculo puro sobre arrays ya extraídos (sin dependencias de ESAPI): seguro de llamar
+        // desde un hilo de fondo y de paralelizar.
+        public static AnalysisResult Evaluate(PortalDoseSnapshot imgRef, PortalDoseSnapshot imgEval, int sessionIdx)
         {
-            string fieldId = imgRef.Beam?.Id ?? imgEval.Beam?.Id ?? "N/A";
-            string dateStr = imgEval.CreationDateTime.HasValue ? imgEval.CreationDateTime.Value.ToShortDateString() : "N/A";
+            string fieldId = imgRef.FieldId ?? imgEval.FieldId ?? "N/A";
+            string dateStr = imgEval.Date;
 
             int sizeX = imgRef.XSize;
             int sizeY = imgRef.YSize;
@@ -102,12 +138,8 @@ namespace VMS.TPS
                 };
             }
 
-            // ESAPI Best Practice: GetVoxels requires int[,] arrays
-            int[,] buffRef = new int[sizeX, sizeY];
-            int[,] buffEval = new int[sizeX, sizeY];
-
-            imgRef.GetVoxels(0, buffRef);
-            imgEval.GetVoxels(0, buffEval);
+            int[,] buffRef = imgRef.Voxels;
+            int[,] buffEval = imgEval.Voxels;
 
             int maxDoseRef = 0;
             int maxDoseEval = 0;
@@ -133,56 +165,67 @@ namespace VMS.TPS
             double doseTol = maxDoseRef * DOSE_CRITERIA_PERCENT;
             double distTolSq = DTA_CRITERIA * DTA_CRITERIA;
             double thresholdVal = maxDoseRef * THRESHOLD_PERCENT;
+            int searchRadiusX = (int)Math.Ceiling(DTA_CRITERIA / resX) + 1;
+
+            // El patrón de desplazamientos (dx, dy) a explorar es el mismo para todos los puntos
+            // de la imagen (depende solo del radio y la resolución), así que se calcula una única
+            // vez, ordenado por distancia ascendente, para poder cortar la búsqueda en cuanto un
+            // punto cumple el criterio de gamma en vez de recorrer siempre toda la ventana.
+            var searchOffsets = BuildSearchOffsets(searchRadiusX, resX, distTolSq);
 
             int pointsEvaluated = 0;
             int pointsPassed = 0;
-            int searchRadiusX = (int)Math.Ceiling(DTA_CRITERIA / resX) + 1;
+            object sumLock = new object();
 
-            for (int x = 0; x < sizeX; x++)
-            {
-                for (int y = 0; y < sizeY; y++)
+            // Cada fila (x) es independiente: se reparte entre hilos y se combinan los totales al final.
+            Parallel.For(0, sizeX,
+                () => (evaluated: 0, passed: 0),
+                (x, loopState, local) =>
                 {
-                    double dRef = buffRef[x, y];
-                    if (dRef < thresholdVal) continue;
+                    int localEvaluated = local.evaluated;
+                    int localPassed = local.passed;
 
-                    pointsEvaluated++;
-                    int xEvalBase = x - shiftX;
-                    int yEvalBase = y - shiftY;
-
-                    if (IsInside(xEvalBase, yEvalBase, sizeX, sizeY))
+                    for (int y = 0; y < sizeY; y++)
                     {
-                        if (Math.Abs(dRef - buffEval[xEvalBase, yEvalBase]) <= doseTol)
+                        double dRef = buffRef[x, y];
+                        if (dRef < thresholdVal) continue;
+
+                        localEvaluated++;
+                        int xEvalBase = x - shiftX;
+                        int yEvalBase = y - shiftY;
+
+                        if (IsInside(xEvalBase, yEvalBase, sizeX, sizeY) &&
+                            Math.Abs(dRef - buffEval[xEvalBase, yEvalBase]) <= doseTol)
                         {
-                            pointsPassed++;
+                            localPassed++;
                             continue;
                         }
-                    }
 
-                    bool passed = false;
-                    int xMin = Math.Max(0, xEvalBase - searchRadiusX);
-                    int xMax = Math.Min(sizeX - 1, xEvalBase + searchRadiusX);
-                    int yMin = Math.Max(0, yEvalBase - searchRadiusX);
-                    int yMax = Math.Min(sizeY - 1, yEvalBase + searchRadiusX);
-
-                    for (int i = xMin; i <= xMax; i++)
-                    {
-                        for (int j = yMin; j <= yMax; j++)
+                        bool passed = false;
+                        foreach (var off in searchOffsets)
                         {
-                            double distSqMm = ((i - xEvalBase) * resX * (i - xEvalBase) * resX) +
-                                              ((j - yEvalBase) * resX * (j - yEvalBase) * resX);
-
-                            if (distSqMm > distTolSq) continue;
+                            int i = xEvalBase + off.dx;
+                            int j = yEvalBase + off.dy;
+                            if (!IsInside(i, j, sizeX, sizeY)) continue;
 
                             double doseDiff = Math.Abs(dRef - buffEval[i, j]);
-                            double gammaSq = (doseDiff * doseDiff) / (doseTol * doseTol) + (distSqMm) / distTolSq;
+                            double gammaSq = (doseDiff * doseDiff) / (doseTol * doseTol) + off.distSqMm / distTolSq;
 
                             if (gammaSq <= 1.0) { passed = true; break; }
                         }
-                        if (passed) break;
+                        if (passed) localPassed++;
                     }
-                    if (passed) pointsPassed++;
-                }
-            }
+
+                    return (localEvaluated, localPassed);
+                },
+                local =>
+                {
+                    lock (sumLock)
+                    {
+                        pointsEvaluated += local.evaluated;
+                        pointsPassed += local.passed;
+                    }
+                });
 
             double passRate = (double)pointsPassed / Math.Max(1, pointsEvaluated) * 100.0;
 
@@ -195,6 +238,20 @@ namespace VMS.TPS
                 Status = passRate >= PASS_LIMIT ? "APROBADO" : "FALLO",
                 Details = $"Shift: {shiftX},{shiftY} px. Puntos: {pointsEvaluated}"
             };
+        }
+
+        private static (int dx, int dy, double distSqMm)[] BuildSearchOffsets(int radius, double res, double distTolSq)
+        {
+            var offsets = new List<(int dx, int dy, double distSqMm)>();
+            for (int dx = -radius; dx <= radius; dx++)
+            {
+                for (int dy = -radius; dy <= radius; dy++)
+                {
+                    double distSqMm = (dx * res * dx * res) + (dy * res * dy * res);
+                    if (distSqMm <= distTolSq) offsets.Add((dx, dy, distSqMm));
+                }
+            }
+            return offsets.OrderBy(o => o.distSqMm).ToArray();
         }
 
         private static bool IsInside(int x, int y, int sx, int sy) => x >= 0 && x < sx && y >= 0 && y < sy;
@@ -396,14 +453,20 @@ namespace VMS.TPS
             }
         }
 
-        private void BtnAnalyze_Click(object sender, RoutedEventArgs e)
+        private async void BtnAnalyze_Click(object sender, RoutedEventArgs e)
         {
-            var results = new List<AnalysisResult>();
-            _status.Text = "Procesando...";
+            var btnAnalyze = sender as Button;
+            if (btnAnalyze != null) btnAnalyze.IsEnabled = false;
+            _status.Text = "Leyendo imágenes...";
             _grid.ItemsSource = null; // Limpiar
 
             try
             {
+                // Preparar los trabajos a evaluar. Esto SÍ toca objetos ESAPI (PortalDoseImage,
+                // Beam, etc.), así que debe ejecutarse en el hilo de UI, pero solo copia los
+                // voxeles a memoria — no calcula gamma, por lo que es rápido.
+                var jobs = new List<(PortalDoseSnapshot refImg, PortalDoseSnapshot evalImg, int session, string fieldId)>();
+
                 if (_isAllFieldsMode)
                 {
                     // LÓGICA PARA TODOS LOS CAMPOS
@@ -422,34 +485,22 @@ namespace VMS.TPS
 
                         // Ordenar y tomar la primera como Referencia Automática
                         fieldImages = fieldImages.OrderBy(i => i.CreationDateTime).ToList();
-                        var refImg = fieldImages[0];
+                        var refSnap = PortalDoseSnapshot.From(fieldImages[0], beam.Id);
 
                         // Comparar el resto
                         int counter = 1;
                         for (int i = 1; i < fieldImages.Count; i++) // Empezar en 1 (saltar Ref)
                         {
-                            var evalImg = fieldImages[i];
-                            int session = counter++;
-                            try
-                            {
-                                results.Add(GammaCalculator.Evaluate(refImg, evalImg, session));
-                            }
-                            catch (Exception exField)
-                            {
-                                results.Add(new AnalysisResult
-                                {
-                                    FieldId = beam.Id,
-                                    Date = evalImg.CreationDateTime.HasValue ? evalImg.CreationDateTime.Value.ToShortDateString() : "N/A",
-                                    SessionNumber = session,
-                                    GammaPassRate = 0,
-                                    Status = "ERROR",
-                                    Details = exField.Message
-                                });
-                            }
+                            var evalSnap = PortalDoseSnapshot.From(fieldImages[i], beam.Id);
+                            jobs.Add((refSnap, evalSnap, counter++, beam.Id));
                         }
                     }
 
-                    if (results.Count == 0) MessageBox.Show("No se encontraron suficientes imágenes en los campos del plan.");
+                    if (jobs.Count == 0)
+                    {
+                        MessageBox.Show("No se encontraron suficientes imágenes en los campos del plan.");
+                        return;
+                    }
                 }
                 else
                 {
@@ -462,32 +513,23 @@ namespace VMS.TPS
 
                     int refIdx = _cbRefImage.SelectedIndex;
                     if (refIdx < 0) return;
-                    var refImg = _singleFieldImages[refIdx];
+
+                    string fieldId = _cbFields.SelectedItem?.ToString();
+                    var refSnap = PortalDoseSnapshot.From(_singleFieldImages[refIdx], fieldId);
 
                     int counter = 1;
                     for (int i = 0; i < _singleFieldImages.Count; i++)
                     {
                         if (i == refIdx) continue;
-                        var evalImg = _singleFieldImages[i];
-                        int session = counter++;
-                        try
-                        {
-                            results.Add(GammaCalculator.Evaluate(refImg, evalImg, session));
-                        }
-                        catch (Exception exField)
-                        {
-                            results.Add(new AnalysisResult
-                            {
-                                FieldId = _cbFields.SelectedItem?.ToString(),
-                                Date = evalImg.CreationDateTime.HasValue ? evalImg.CreationDateTime.Value.ToShortDateString() : "N/A",
-                                SessionNumber = session,
-                                GammaPassRate = 0,
-                                Status = "ERROR",
-                                Details = exField.Message
-                            });
-                        }
+                        var evalSnap = PortalDoseSnapshot.From(_singleFieldImages[i], fieldId);
+                        jobs.Add((refSnap, evalSnap, counter++, fieldId));
                     }
                 }
+
+                // El cálculo de gamma es matemática pura sobre arrays ya copiados: se ejecuta en
+                // un hilo de fondo para no congelar la UI, reportando avance por cada comparación.
+                var progress = new Progress<int>(done => _status.Text = $"Procesando... {done}/{jobs.Count}");
+                var results = await Task.Run(() => RunJobs(jobs, progress));
 
                 _grid.ItemsSource = results;
                 _status.Text = $"Completado: {results.Count} análisis.";
@@ -495,7 +537,43 @@ namespace VMS.TPS
             catch (Exception ex)
             {
                 MessageBox.Show("Error: " + ex.Message);
+                _status.Text = "Error.";
             }
+            finally
+            {
+                if (btnAnalyze != null) btnAnalyze.IsEnabled = true;
+            }
+        }
+
+        private static List<AnalysisResult> RunJobs(
+            List<(PortalDoseSnapshot refImg, PortalDoseSnapshot evalImg, int session, string fieldId)> jobs,
+            IProgress<int> progress)
+        {
+            var results = new List<AnalysisResult>(jobs.Count);
+
+            for (int idx = 0; idx < jobs.Count; idx++)
+            {
+                var job = jobs[idx];
+                try
+                {
+                    results.Add(GammaCalculator.Evaluate(job.refImg, job.evalImg, job.session));
+                }
+                catch (Exception exField)
+                {
+                    results.Add(new AnalysisResult
+                    {
+                        FieldId = job.fieldId,
+                        Date = job.evalImg.Date,
+                        SessionNumber = job.session,
+                        GammaPassRate = 0,
+                        Status = "ERROR",
+                        Details = exField.Message
+                    });
+                }
+                progress.Report(idx + 1);
+            }
+
+            return results;
         }
 
         private void BtnExport_Click(object sender, RoutedEventArgs e)

--- a/HalcyonGammaCheck_v3.csproj
+++ b/HalcyonGammaCheck_v3.csproj
@@ -59,7 +59,13 @@
     <Reference Include="PresentationFramework" />
   </ItemGroup>
   <ItemGroup>
-    <Compile Include="HalcyonGammaCheck_v3.cs" />
+    <Compile Include="Script.cs" />
+    <Compile Include="AssemblyInfo.cs" />
+    <Compile Include="AnalysisResult.cs" />
+    <Compile Include="PortalDoseSnapshot.cs" />
+    <Compile Include="GammaCalculator.cs" />
+    <Compile Include="MainView.cs" />
+    <Compile Include="ActivityLogger.cs" />
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
 </Project>

--- a/MainView.cs
+++ b/MainView.cs
@@ -3,274 +3,16 @@ using System.Collections.Generic;
 using System.Globalization;
 using System.IO;
 using System.Linq;
-using System.Reflection;
-using System.Runtime.CompilerServices;
-using System.Text;
 using System.Threading.Tasks;
 using System.Windows;
 using System.Windows.Controls;
 using System.Windows.Data;
 using System.Windows.Media;
-using VMS.TPS.Common.Model.API; // ESAPI types (ensure project references VMS.TPS.Common.Model.API.dll)
-using VMS.TPS.Common.Model.Types;
-
-// TODO: Replace the following version attributes by creating AssemblyInfo.cs. You can do this in the properties of the Visual Studio project.
-[assembly: AssemblyVersion("1.0.0.1")]
-[assembly: AssemblyFileVersion("1.0.0.1")]
-[assembly: AssemblyInformationalVersion("1.0")]
-
-// TODO: Uncomment the following line if the script requires write access.
-//[assembly: ESAPIScript(IsWriteable = false)]
+using Microsoft.Win32;
+using VMS.TPS.Common.Model.API;
 
 namespace VMS.TPS
 {
-    public class Script
-    {
-        public Script()
-        {
-        }
-
-        [MethodImpl(MethodImplOptions.NoInlining)]
-        public void Execute(ScriptContext context, System.Windows.Window window, ScriptEnvironment environment)
-        {
-            // TODO : Add here the code that is called when the script is launched from Eclipse.
-            if (context.Patient == null)
-            {
-                MessageBox.Show("Por favor, carga un paciente.");
-                return;
-            }
-
-            var view = new MainView(context.Patient);
-            window.Content = view;
-            window.Title = $"Halcyon PD Constancy Check - {context.Patient.Id} (All Fields)";
-            window.Width = 1000;
-            window.Height = 750;
-        }
-    }
-
-    // -------------------------------------------------------------------------
-    // LÓGICA GAMMA
-    // -------------------------------------------------------------------------
-    public class AnalysisResult
-    {
-        public string FieldId { get; set; }
-        public string Date { get; set; }
-        public int SessionNumber { get; set; }
-        public double GammaPassRate { get; set; }
-        public string Status { get; set; }
-        public string Details { get; set; }
-    }
-
-    // Copia inmutable de los datos de una PortalDoseImage necesarios para el cálculo de gamma.
-    // Se construye en el hilo de UI (donde es seguro llamar a ESAPI) para que el cálculo puro
-    // pueda ejecutarse después en un hilo de fondo sin volver a tocar objetos ESAPI.
-    public class PortalDoseSnapshot
-    {
-        public string FieldId { get; set; }
-        public string Date { get; set; }
-        public int[,] Voxels { get; set; }
-        public int XSize { get; set; }
-        public int YSize { get; set; }
-        public double XRes { get; set; }
-        public double YRes { get; set; }
-
-        public static PortalDoseSnapshot From(PortalDoseImage img, string fieldIdOverride = null)
-        {
-            int sx = img.XSize;
-            int sy = img.YSize;
-            var buff = new int[sx, sy];
-            img.GetVoxels(0, buff);
-
-            return new PortalDoseSnapshot
-            {
-                FieldId = fieldIdOverride ?? img.Beam?.Id,
-                Date = img.CreationDateTime.HasValue ? img.CreationDateTime.Value.ToShortDateString() : "N/A",
-                Voxels = buff,
-                XSize = sx,
-                YSize = sy,
-                XRes = img.XRes,
-                YRes = img.YRes
-            };
-        }
-    }
-
-    public class GammaCalculator
-    {
-        private const double DTA_CRITERIA = 3.0; // mm
-        private const double DOSE_CRITERIA_PERCENT = 0.03; // 3%
-        private const double THRESHOLD_PERCENT = 0.10; // 10%
-        private const double PASS_LIMIT = 95.0; // %
-
-        // Cálculo puro sobre arrays ya extraídos (sin dependencias de ESAPI): seguro de llamar
-        // desde un hilo de fondo y de paralelizar.
-        public static AnalysisResult Evaluate(PortalDoseSnapshot imgRef, PortalDoseSnapshot imgEval, int sessionIdx)
-        {
-            string fieldId = imgRef.FieldId ?? imgEval.FieldId ?? "N/A";
-            string dateStr = imgEval.Date;
-
-            int sizeX = imgRef.XSize;
-            int sizeY = imgRef.YSize;
-            double resX = imgRef.XRes;
-
-            if (imgEval.XSize != sizeX || imgEval.YSize != sizeY)
-            {
-                return new AnalysisResult
-                {
-                    FieldId = fieldId,
-                    Date = dateStr,
-                    SessionNumber = sessionIdx,
-                    GammaPassRate = 0,
-                    Status = "ERROR",
-                    Details = $"Tamaño de imagen distinto (Ref: {sizeX}x{sizeY}, Eval: {imgEval.XSize}x{imgEval.YSize})"
-                };
-            }
-
-            if (Math.Abs(imgEval.XRes - resX) > 1e-6 || Math.Abs(imgEval.YRes - imgRef.YRes) > 1e-6)
-            {
-                return new AnalysisResult
-                {
-                    FieldId = fieldId,
-                    Date = dateStr,
-                    SessionNumber = sessionIdx,
-                    GammaPassRate = 0,
-                    Status = "ERROR",
-                    Details = $"Resolución distinta (Ref: {resX:F3}mm, Eval: {imgEval.XRes:F3}mm)"
-                };
-            }
-
-            int[,] buffRef = imgRef.Voxels;
-            int[,] buffEval = imgEval.Voxels;
-
-            int maxDoseRef = 0;
-            int maxDoseEval = 0;
-            for (int x = 0; x < sizeX; x++)
-            {
-                for (int y = 0; y < sizeY; y++)
-                {
-                    if (buffRef[x, y] > maxDoseRef) maxDoseRef = buffRef[x, y];
-                    if (buffEval[x, y] > maxDoseEval) maxDoseEval = buffEval[x, y];
-                }
-            }
-
-            if (maxDoseRef <= 0) return new AnalysisResult { FieldId = fieldId, Date = dateStr, SessionNumber = sessionIdx, Status = "ERROR", Details = "Ref Vacía" };
-
-            // Auto-Alineación (Using each image's own max dose for thresholding)
-            Point comRef = GetCenterOfMass(buffRef, sizeX, sizeY, maxDoseRef * 0.2);
-            Point comEval = GetCenterOfMass(buffEval, sizeX, sizeY, maxDoseEval * 0.2);
-
-            int shiftX = (int)Math.Round(comRef.X - comEval.X);
-            int shiftY = (int)Math.Round(comRef.Y - comEval.Y);
-
-            // Gamma
-            double doseTol = maxDoseRef * DOSE_CRITERIA_PERCENT;
-            double distTolSq = DTA_CRITERIA * DTA_CRITERIA;
-            double thresholdVal = maxDoseRef * THRESHOLD_PERCENT;
-            int searchRadiusX = (int)Math.Ceiling(DTA_CRITERIA / resX) + 1;
-
-            // El patrón de desplazamientos (dx, dy) a explorar es el mismo para todos los puntos
-            // de la imagen (depende solo del radio y la resolución), así que se calcula una única
-            // vez, ordenado por distancia ascendente, para poder cortar la búsqueda en cuanto un
-            // punto cumple el criterio de gamma en vez de recorrer siempre toda la ventana.
-            var searchOffsets = BuildSearchOffsets(searchRadiusX, resX, distTolSq);
-
-            int pointsEvaluated = 0;
-            int pointsPassed = 0;
-            object sumLock = new object();
-
-            // Cada fila (x) es independiente: se reparte entre hilos y se combinan los totales al final.
-            Parallel.For(0, sizeX,
-                () => (evaluated: 0, passed: 0),
-                (x, loopState, local) =>
-                {
-                    int localEvaluated = local.evaluated;
-                    int localPassed = local.passed;
-
-                    for (int y = 0; y < sizeY; y++)
-                    {
-                        double dRef = buffRef[x, y];
-                        if (dRef < thresholdVal) continue;
-
-                        localEvaluated++;
-                        int xEvalBase = x - shiftX;
-                        int yEvalBase = y - shiftY;
-
-                        if (IsInside(xEvalBase, yEvalBase, sizeX, sizeY) &&
-                            Math.Abs(dRef - buffEval[xEvalBase, yEvalBase]) <= doseTol)
-                        {
-                            localPassed++;
-                            continue;
-                        }
-
-                        bool passed = false;
-                        foreach (var off in searchOffsets)
-                        {
-                            int i = xEvalBase + off.dx;
-                            int j = yEvalBase + off.dy;
-                            if (!IsInside(i, j, sizeX, sizeY)) continue;
-
-                            double doseDiff = Math.Abs(dRef - buffEval[i, j]);
-                            double gammaSq = (doseDiff * doseDiff) / (doseTol * doseTol) + off.distSqMm / distTolSq;
-
-                            if (gammaSq <= 1.0) { passed = true; break; }
-                        }
-                        if (passed) localPassed++;
-                    }
-
-                    return (localEvaluated, localPassed);
-                },
-                local =>
-                {
-                    lock (sumLock)
-                    {
-                        pointsEvaluated += local.evaluated;
-                        pointsPassed += local.passed;
-                    }
-                });
-
-            double passRate = (double)pointsPassed / Math.Max(1, pointsEvaluated) * 100.0;
-
-            return new AnalysisResult
-            {
-                FieldId = fieldId,
-                Date = dateStr,
-                SessionNumber = sessionIdx,
-                GammaPassRate = passRate,
-                Status = passRate >= PASS_LIMIT ? "APROBADO" : "FALLO",
-                Details = $"Shift: {shiftX},{shiftY} px. Puntos: {pointsEvaluated}"
-            };
-        }
-
-        private static (int dx, int dy, double distSqMm)[] BuildSearchOffsets(int radius, double res, double distTolSq)
-        {
-            var offsets = new List<(int dx, int dy, double distSqMm)>();
-            for (int dx = -radius; dx <= radius; dx++)
-            {
-                for (int dy = -radius; dy <= radius; dy++)
-                {
-                    double distSqMm = (dx * res * dx * res) + (dy * res * dy * res);
-                    if (distSqMm <= distTolSq) offsets.Add((dx, dy, distSqMm));
-                }
-            }
-            return offsets.OrderBy(o => o.distSqMm).ToArray();
-        }
-
-        private static bool IsInside(int x, int y, int sx, int sy) => x >= 0 && x < sx && y >= 0 && y < sy;
-
-        private static Point GetCenterOfMass(int[,] img, int sx, int sy, double thresh)
-        {
-            double sumW = 0, sumX = 0, sumY = 0;
-            for (int x = 0; x < sx; x++)
-            {
-                for (int y = 0; y < sy; y++)
-                {
-                    double val = img[x, y];
-                    if (val > thresh) { sumW += val; sumX += x * val; sumY += y * val; }
-                }
-            }
-            return sumW == 0 ? new Point(sx / 2, sy / 2) : new Point(sumX / sumW, sumY / sumW);
-        }
-    }
-
     // -------------------------------------------------------------------------
     // INTERFAZ GRÁFICA (Con opción TODOS LOS CAMPOS)
     // -------------------------------------------------------------------------
@@ -533,11 +275,18 @@ namespace VMS.TPS
 
                 _grid.ItemsSource = results;
                 _status.Text = $"Completado: {results.Count} análisis.";
+
+                int passCount = results.Count(r => r.Status == "APROBADO");
+                int failCount = results.Count(r => r.Status == "FALLO");
+                int errorCount = results.Count(r => r.Status == "ERROR");
+                string modeLabel = _isAllFieldsMode ? "TODOS_LOS_CAMPOS" : _cbFields.SelectedItem?.ToString();
+                ActivityLogger.Log($"ANALISIS\tPaciente={_patient.Id}\tCurso={_cbCourses.SelectedItem}\tPlan={_currentPlan?.Id}\tCampo={modeLabel}\tTotal={results.Count}\tAprobado={passCount}\tFallo={failCount}\tError={errorCount}");
             }
             catch (Exception ex)
             {
                 MessageBox.Show("Error: " + ex.Message);
                 _status.Text = "Error.";
+                ActivityLogger.Log($"ANALISIS_ERROR\tPaciente={_patient?.Id}\tMensaje={ex.Message}");
             }
             finally
             {
@@ -579,22 +328,35 @@ namespace VMS.TPS
         private void BtnExport_Click(object sender, RoutedEventArgs e)
         {
             var data = _grid.ItemsSource as List<AnalysisResult>;
-            if (data == null || !data.Any()) 
+            if (data == null || !data.Any())
             {
                 MessageBox.Show("No hay datos para exportar. Ejecute un análisis primero.");
                 return;
             }
 
-            string path = @"C:\Temp\PortalDosimetryReports";
-            if (!Directory.Exists(path)) Directory.CreateDirectory(path);
+            string defaultDir = @"C:\Temp\PortalDosimetryReports";
+            try { if (!Directory.Exists(defaultDir)) Directory.CreateDirectory(defaultDir); }
+            catch { /* Si no se puede crear, el diálogo caerá a su carpeta por defecto */ }
 
             string fieldName = _isAllFieldsMode ? "ALL_FIELDS" : _cbFields.SelectedItem.ToString();
-            
+
             // Sanitizar Patient ID para evitar caracteres ilegales en el nombre del archivo
             string safePatientId = string.Join("_", _patient.Id.Split(Path.GetInvalidFileNameChars()));
             string safePlanId = _currentPlan != null ? string.Join("_", _currentPlan.Id.Split(Path.GetInvalidFileNameChars())) : "NoPlan";
 
-            string file = Path.Combine(path, $"HalcyonQA_{safePatientId}_{safePlanId}_{fieldName}_{DateTime.Now:yyyyMMdd_HHmm}.csv");
+            string defaultFileName = $"HalcyonQA_{safePatientId}_{safePlanId}_{fieldName}_{DateTime.Now:yyyyMMdd_HHmm}.csv";
+
+            var dialog = new SaveFileDialog
+            {
+                Title = "Exportar reporte de QA",
+                Filter = "Archivo CSV (*.csv)|*.csv",
+                FileName = defaultFileName,
+                InitialDirectory = Directory.Exists(defaultDir) ? defaultDir : Environment.GetFolderPath(Environment.SpecialFolder.MyDocuments)
+            };
+
+            if (dialog.ShowDialog() != true) return; // El usuario canceló
+
+            string file = dialog.FileName;
 
             try
             {
@@ -619,8 +381,13 @@ namespace VMS.TPS
                     }
                 }
                 MessageBox.Show($"Exportado a:\n{file}");
+                ActivityLogger.Log($"EXPORT\tPaciente={_patient.Id}\tArchivo={file}");
             }
-            catch (Exception ex) { MessageBox.Show("Error exportando: " + ex.Message); }
+            catch (Exception ex)
+            {
+                MessageBox.Show("Error exportando: " + ex.Message);
+                ActivityLogger.Log($"EXPORT_ERROR\tPaciente={_patient?.Id}\tMensaje={ex.Message}");
+            }
         }
 
         // Escapa un campo para CSV (RFC 4180): entrecomilla si contiene coma, comilla o salto de línea.

--- a/PortalDoseSnapshot.cs
+++ b/PortalDoseSnapshot.cs
@@ -1,0 +1,37 @@
+using VMS.TPS.Common.Model.API;
+
+namespace VMS.TPS
+{
+    // Copia inmutable de los datos de una PortalDoseImage necesarios para el cálculo de gamma.
+    // Se construye en el hilo de UI (donde es seguro llamar a ESAPI) para que el cálculo puro
+    // pueda ejecutarse después en un hilo de fondo sin volver a tocar objetos ESAPI.
+    public class PortalDoseSnapshot
+    {
+        public string FieldId { get; set; }
+        public string Date { get; set; }
+        public int[,] Voxels { get; set; }
+        public int XSize { get; set; }
+        public int YSize { get; set; }
+        public double XRes { get; set; }
+        public double YRes { get; set; }
+
+        public static PortalDoseSnapshot From(PortalDoseImage img, string fieldIdOverride = null)
+        {
+            int sx = img.XSize;
+            int sy = img.YSize;
+            var buff = new int[sx, sy];
+            img.GetVoxels(0, buff);
+
+            return new PortalDoseSnapshot
+            {
+                FieldId = fieldIdOverride ?? img.Beam?.Id,
+                Date = img.CreationDateTime.HasValue ? img.CreationDateTime.Value.ToShortDateString() : "N/A",
+                Voxels = buff,
+                XSize = sx,
+                YSize = sy,
+                XRes = img.XRes,
+                YRes = img.YRes
+            };
+        }
+    }
+}

--- a/Script.cs
+++ b/Script.cs
@@ -1,0 +1,29 @@
+using System.Runtime.CompilerServices;
+using System.Windows;
+using VMS.TPS.Common.Model.API;
+
+namespace VMS.TPS
+{
+    public class Script
+    {
+        public Script()
+        {
+        }
+
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        public void Execute(ScriptContext context, System.Windows.Window window, ScriptEnvironment environment)
+        {
+            if (context.Patient == null)
+            {
+                MessageBox.Show("Por favor, carga un paciente.");
+                return;
+            }
+
+            var view = new MainView(context.Patient);
+            window.Content = view;
+            window.Title = $"Halcyon PD Constancy Check - {context.Patient.Id} (All Fields)";
+            window.Width = 1000;
+            window.Height = 750;
+        }
+    }
+}


### PR DESCRIPTION
- Escape CSV fields (RFC 4180) so commas in Details no longer misalign columns
- Format numbers with InvariantCulture in the CSV export to avoid
  decimal-comma vs delimiter-comma collisions on es-* locales
- Catch failures per field/comparison in BtnAnalyze_Click instead of
  aborting the whole batch, tagging the offending row as ERROR
- Validate matching image size/resolution before comparing voxel buffers
  in GammaCalculator.Evaluate, returning a clear ERROR result instead of
  relying on an opaque exception