### PR TITLE
Fix CSV/locale bugs, isolate per-comparison errors, run gamma off the UI thread, split into files

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,35 +1,50 @@
 # ✅ ESAPI Halcyon Gamma Check
 
 ## 📖 Overview
-The **ESAPI Halcyon Gamma Check** is an open-source clinical tool developed for the Varian Eclipse Treatment Planning System (TPS). 
+The **ESAPI Halcyon Gamma Check** is an open-source ESAPI plugin script for the Varian Eclipse Treatment Planning System (TPS).
 
-Designed specifically for the Varian Halcyon linear accelerator workflow, this script automates the verification and quality assurance (QA) steps required for complex VMAT and IMRT plans. By standardizing the evaluation of plan metrics and QA verification plans, this tool ensures that every treatment sent to the Halcyon meets strict institutional safety and deliverability constraints before treating the patient.
+For a Halcyon treatment plan, it performs a **portal dosimetry (EPID) gamma constancy check across sessions**: for a selected field — or every field in the plan at once — it compares each delivered `PortalDoseImage` against a reference image (typically the first session) using a 2D gamma index, with automatic center-of-mass alignment, flags sessions below the institutional pass rate, and exports the results to CSV for the QA record.
 
 ## ✨ Key Features
-* **Halcyon-Specific Validation:** Checks plan parameters against the unique physical and dosimetric constraints of the Halcyon system.
-* **Automated QA Workflow:** Streamlines the creation or verification of QA plans, ensuring consistency across the dosimetric team.
-* **Standardized Reporting:** Generates clear, objective pass/fail metrics for pre-treatment plan reviews.
-* **Error Mitigation:** Reduces human oversight in complex VMAT parameter checks, enhancing overall patient safety.
+* **Portal Dosimetry Gamma Analysis:** 2D gamma index (3%/3mm, global normalization, 10% low-dose threshold by default) between a reference `PortalDoseImage` and each subsequent session, with automatic center-of-mass alignment.
+* **Single-Field or All-Fields Batch Mode:** Analyze one field manually, or run `-- ANALIZAR TODOS --` to auto-compare every treatment field in the plan against its own earliest session.
+* **Responsive UI:** Image reading is synchronous, but the gamma computation runs on a background thread (parallelized per image row) with live progress in the status bar, so the window never freezes during a batch analysis.
+* **Per-Comparison Error Isolation:** A problem with one session/field (mismatched image size or resolution, corrupted image, etc.) is reported as an `ERROR` row instead of aborting the whole batch.
+* **CSV Export:** Save results via a standard Save dialog; fields are properly escaped and numbers use culture-invariant formatting, so the report opens cleanly in Excel regardless of the OS locale.
+* **Minimal Audit Log:** Every analysis run and export is appended to a local log file (patient, plan, field, pass/fail/error counts, user, timestamp) for institutional traceability.
 
 ## 💻 System Requirements
-* **Eclipse TPS:** Version 15.5 or higher.
-* **.NET Framework:** Compatible with your clinic's specific ESAPI version (e.g., 4.5 for v15.6, or 4.6+ for v16+).
+* **Eclipse TPS / ESAPI:** Built against `VMS.TPS.Common.Model.API` v1.0.600.194 (Varian RTM 18.0). If your clinic runs a different ESAPI version, update the reference `HintPath`s in `HalcyonGammaCheck_v3.csproj` accordingly.
+* **.NET Framework:** 4.8 (as configured in `HalcyonGammaCheck_v3.csproj`).
+
+## 🗂️ Project Structure
+| File | Responsibility |
+|---|---|
+| `Script.cs` | ESAPI entry point (`Script.Execute`), launched by Eclipse's Script Runner. |
+| `MainView.cs` | WPF UI: course/plan/field selection, analysis grid, CSV export. |
+| `GammaCalculator.cs` | Pure gamma-index math — no ESAPI dependency, safe to run on a background thread or unit test. |
+| `PortalDoseSnapshot.cs` | Immutable copy of a `PortalDoseImage`'s voxels/metadata, used to hand data from the UI thread to the background computation. |
+| `AnalysisResult.cs` | Result row shown in the grid and exported to CSV. |
+| `ActivityLogger.cs` | Best-effort audit logging. |
+| `AssemblyInfo.cs` | Assembly version and `[ESAPIScript(IsWriteable = false)]`. |
 
 ## 🛠️ Installation & Compilation
 To ensure proper functionality within the Eclipse environment, this project must be compiled into a `.dll` library.
 
 1. Clone or download this repository to your local machine.
 2. Open the solution file (`.sln`) using **Visual Studio**.
-3. In the Solution Explorer, right-click the solution and select **Restore NuGet Packages**.
+3. Verify the `VMS.TPS.Common.Model.API` / `VMS.TPS.Common.Model.Types` reference paths in `HalcyonGammaCheck_v3.csproj` point to your Eclipse/ESAPI installation.
 4. Build the solution (`Ctrl + Shift + B` or `Build > Build Solution`).
 5. Locate the compiled `.dll` file inside the `bin\Debug` or `bin\Release` folder.
 6. In Eclipse, open the Script Runner, navigate to the folder containing your compiled `.dll`, and execute it.
 
 ## 🚀 How to Use
-1. Open a Patient and the corresponding Halcyon Treatment Plan in Eclipse.
-2. Run the compiled Halcyon Gamma Check `.dll`.
-3. Review the automated QA checklist and validation results presented in the script's UI.
-4. Ensure all metrics pass the institutional protocols before exporting the plan to the delivery system.
+1. Open a Patient in Eclipse and run the compiled Halcyon Gamma Check `.dll`.
+2. Select the **Course**, **Plan**, and either a single **Field** or `-- ANALIZAR TODOS --` to compare every field in the plan.
+3. For single-field mode, choose the reference session (defaults to session 1); in all-fields mode, the earliest session of each field is used automatically.
+4. Click **ANALIZAR** and watch the status bar for progress. Results appear in the grid, color-coded `APROBADO` / `FALLO` / `ERROR`.
+5. Click **Exportar CSV** and choose where to save the report (defaults to `C:\Temp\PortalDosimetryReports`).
+6. Ensure all metrics pass institutional protocols before treating the patient on the Halcyon system.
 
 ## 📄 License
 This project is licensed under the MIT License - see the [LICENSE](LICENSE) file for details.


### PR DESCRIPTION
## Summary

Code review pass over the Halcyon gamma constancy check plugin, covering correctness bugs, performance, and maintainability.

- **CSV export was broken**: `Details` always contained a comma (`Shift: X,Y px...`), misaligning every exported row; numeric formatting also used the current OS culture, which collides with the comma delimiter on es-* locales. Fields are now RFC 4180-escaped and numbers use `CultureInfo.InvariantCulture`.
- **One bad session/field no longer kills the whole batch**: each comparison is evaluated independently; a failure (mismatched image size/resolution, corrupted image, etc.) now shows up as an `ERROR` row instead of aborting the entire "TODOS LOS CAMPOS" run.
- **Image size/resolution mismatch** between reference and evaluated `PortalDoseImage` is now validated explicitly before touching the voxel buffers, instead of relying on an opaque ESAPI exception.
- **UI no longer freezes** during analysis: image reading stays on the UI thread (fast, ESAPI-safe), but the actual gamma computation now runs on a background thread via `Task.Run`, with live progress in the status bar and the Analyze button disabled while running.
- **Faster gamma computation**: the local search offset kernel (dx, dy) is precomputed once per comparison, sorted by ascending distance, so the search can break out as soon as a passing point is found; the per-row gamma search is also parallelized with `Parallel.For`.
- **Split the single ~470-line file** into one class per file (`Script`, `AssemblyInfo`, `AnalysisResult`, `PortalDoseSnapshot`, `GammaCalculator`, `MainView`, `ActivityLogger`), and resolved the leftover VS template TODOs (assembly version attributes moved to `AssemblyInfo.cs`, `[ESAPIScript(IsWriteable = false)]` declared explicitly since the tool never writes to the plan/patient).
- **Configurable CSV export path** via a `SaveFileDialog` (still defaults to `C:\Temp\PortalDosimetryReports`) instead of a hardcoded, non-configurable path.
- **Minimal audit log** (`ActivityLogger`): every analysis run and export is appended to a local log file (timestamp, user, patient/plan/field, pass/fail/error counts) for institutional traceability, best-effort so it never blocks the clinical workflow.
- **README updated** to accurately describe the tool (portal dosimetry gamma constancy check across sessions) and the new project structure/usage flow.

## Test plan

- [ ] Build the solution in Visual Studio against the clinic's ESAPI installation (this session has no Windows/ESAPI toolchain available to compile or run it)
- [ ] Run single-field analysis on a Halcyon plan with ≥2 portal dose sessions; verify results grid and progress reporting
- [ ] Run `-- ANALIZAR TODOS --` batch mode on a plan with multiple fields; verify one bad image doesn't abort the whole batch
- [ ] Export to CSV and confirm columns align correctly and open cleanly in Excel on an es-ES locale machine
- [ ] Confirm the audit log file is created/appended under `C:\Temp\PortalDosimetryReports\Logs\`